### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PySide2
+pypresence


### PR DESCRIPTION
Dans la page "Installation des dépendances" du wiki, il est que pour installer les dépendances sur Windows, il faut faire `pip install -r requirements.txt`. Mais le fichier requirements.txt n'existe pas. Je vous propose donc de le rajouter.